### PR TITLE
feat: added basic JWT authentication

### DIFF
--- a/platform_global_teacher_campus/api/v1/serializers.py
+++ b/platform_global_teacher_campus/api/v1/serializers.py
@@ -10,6 +10,7 @@ from platform_global_teacher_campus.models import (
     ValidationRejectionReason,
     ValidationRules,
 )
+from rest_framework.permissions import IsAuthenticated
 
 CourseOverview = get_course_overview()
 User = get_user_model()
@@ -174,8 +175,7 @@ class ValidationProcessSerializer(serializers.ModelSerializer):
         categories = CourseCategory.objects.filter(id__in=category_ids)
         validation_process.categories.add(*categories)
 
-        # ToDo: Remove thisone when user is working
-        self.context['request'].user = User.objects.get(id=4)
+      
 
         self.create_event(data={
             'validation_process': validation_process,

--- a/platform_global_teacher_campus/api/v1/views.py
+++ b/platform_global_teacher_campus/api/v1/views.py
@@ -15,6 +15,8 @@ from platform_global_teacher_campus.api.v1.serializers import (
     ValidationProcessSerializer,
     ValidationProcessEventSerializer
 )
+from rest_framework.permissions import IsAuthenticated
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 
 
 class CourseCategoryViewSet(viewsets.ModelViewSet):
@@ -28,6 +30,8 @@ class ValidationBodyViewSet(viewsets.ModelViewSet):
 
 
 class ValidationProcessViewSet(viewsets.ModelViewSet):
+    permission_classes = [IsAuthenticated]
+    authentication_classes = (JwtAuthentication,)
     queryset = ValidationProcess.objects.all()
     serializer_class = ValidationProcessSerializer
 


### PR DESCRIPTION
This PR adds basic JWT authentication for the validation process event class.

**How to test**

1. Go to your django admin and create a new application under Home ->Django OAuth  -> Applications
2. Select the User you want to create the token for 
3. In client type select "confidential"
4. In Authorization grant type select "Client credentials", give the app a name and hit save.
5. Make a POST request to local.overhang.io:8000/oauth2/access_token along side newer application's  "client_id", and  " client_secret", add a header "grant_type" with the value of "client_credentials" and a final header "token_type" with the value "jwt" using an API platform like Postman
6. This will generate a JWT token which you need to copy and make a POST request to the endpoint local.overhang.io:8000/plugin-cvw/api/v1/validation-process/
7. Make sure to add the token as an Authorization Header (Key: Autorization, value: JWT {{your_token}}.
8. Please note that you dont need to add autorization explicitly to Postman because the token is directly being sent as the autorization header.
9. You should see the user automatically wihtout explicitly sending the user details in the request body.