### PR TITLE
feat: add a get method that list all allowed validation processes

### DIFF
--- a/platform_global_teacher_campus/api/v1/urls.py
+++ b/platform_global_teacher_campus/api/v1/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('validation-processes/<str:course_id>/submit/', views.submit_validation_process, name="validation-process-submit"),
     path('validation-processes/<str:course_id>/update-state/', views.update_validation_process_state, name='validation-process-update-state'),
     path('validation-processes/<str:course_id>', views.info_validation_process, name="validation-process-info"),
+    path('validation-processes/', views.get_validation_processes, name="get-validation-processes"),
 ]

--- a/platform_global_teacher_campus/api/v1/views.py
+++ b/platform_global_teacher_campus/api/v1/views.py
@@ -18,7 +18,11 @@ from platform_global_teacher_campus.api.v1.serializers import (
     ValidationProcessEventSerializer
 )
 from platform_global_teacher_campus.edxapp_wrapper.users import get_user_model
-from platform_global_teacher_campus.edxapp_wrapper.course_roles import get_course_staff_role
+from platform_global_teacher_campus.edxapp_wrapper.course_roles import (
+    get_course_staff_role,
+    get_course_access_role,
+    get_global_staff
+)
 from platform_global_teacher_campus.edxapp_wrapper.courses import get_course_overview
 from rest_framework.permissions import IsAuthenticated
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
@@ -26,7 +30,9 @@ from rest_framework.decorators import api_view, permission_classes, authenticati
 
 User = get_user_model()
 CourseStaffRole = get_course_staff_role()
+CourseAccessRole = get_course_access_role()
 CourseOverview = get_course_overview()
+GlobalStaff = get_global_staff()
 
 
 class CourseCategoryViewSet(viewsets.ModelViewSet):
@@ -121,3 +127,57 @@ def info_validation_process(request, course_id):
         return Response(serializer.data)  # Return serialized data as JSON
     except ValidationProcess.DoesNotExist:
         return Response({"error": "Validation process not found"}, status=404)
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+def get_validation_processes(request):
+    """
+    Returns the validation processes visible for the username provided or the request user.
+
+    **Example Requests**
+
+    GET /plugin-cvw/api/v1/validation-processes/?username=validator-1
+
+    GET /plugin-cvw/api/v1/validation-processes/
+
+    **Params**
+
+    - `username` (optional, string, _query_params_) - defaults to the calling user if not provided.
+
+    **Responses**
+
+    - 200: Success.
+
+    - 404: Not found.
+    """
+
+    try:
+        username = request.query_params.get('username') or request.user.username
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    # Only staff members can view validation processes from other users.
+    # We don't use 401 to not let them deduce the existence of an user.
+    if user != request.user and not GlobalStaff().has_user(request.user):
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    # Check the validation processes of the courses to which a user has access due to their role in the courses.
+    course_access_roles = list(CourseAccessRole.objects.filter(user=user))
+    course_accesses = [course_access.course_id for course_access in course_access_roles]
+    query_course_access = ValidationProcess.objects.filter(course__in=course_accesses)
+    
+    # Check the validation processes by their Validation Bodies
+    validation_bodies = list(ValidationBody.objects.filter(validators=user))
+    query_validation_body = ValidationProcess.objects.filter(validation_body__in=validation_bodies)
+
+    validation_processes_allowed = list(query_course_access.union(query_validation_body).all())
+    serialized_validation_processes_allowed = [
+        ValidationProcessSerializer(validation_process).data for
+        validation_process in validation_processes_allowed
+    ]
+
+    return Response(
+        status=status.HTTP_200_OK,
+        data=serialized_validation_processes_allowed
+    )

--- a/platform_global_teacher_campus/edxapp_wrapper/backends/course_roles_v1.py
+++ b/platform_global_teacher_campus/edxapp_wrapper/backends/course_roles_v1.py
@@ -1,6 +1,12 @@
-from common.djangoapps.student.roles import (
-    CourseStaffRole
-)
+from common.djangoapps.student.models import CourseAccessRole
+from common.djangoapps.student.roles import CourseStaffRole, GlobalStaff
+
 
 def get_course_staff_role():
     return CourseStaffRole
+
+def get_course_access_role():
+    return CourseAccessRole
+
+def get_global_staff():
+    return GlobalStaff

--- a/platform_global_teacher_campus/edxapp_wrapper/course_roles.py
+++ b/platform_global_teacher_campus/edxapp_wrapper/course_roles.py
@@ -13,3 +13,19 @@ def get_course_staff_role():
     backend = import_module(backend_function)
 
     return backend.get_course_staff_role()
+
+def get_course_access_role():
+    """ Gets the course access role model from edxapp. """
+
+    backend_function = settings.COURSE_ROLE_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_course_access_role()
+
+def get_global_staff():
+    """ Gets the global staff role model from edxapp. """
+
+    backend_function = settings.COURSE_ROLE_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_global_staff()


### PR DESCRIPTION
## Description
This PR adds the get method for the validation processes.

**Implementation notes:**

- First, I'm checking if the user has a role in some course, for example (staff, instructor, etc.). Right now, I'm only checking if it has a role in the course (e.g., if the role is support or beta_tester, I'm letting have access to the associated validation process). Then I search if the user belongs to a validation body and then filter the validation process by that. Finally, I make a union of those two queries.
- Only the global staff can request another user's validation process. (I made this case mostly for testing purposes, and maybe it will be util for staff users)

## How to test

GET /plugin-cvw/api/v1/validation-processes/?username=some_username
GET /plugin-cvw/api/v1/validation-processes/

An easy way to test: http://local.overhang.io:8000/plugin-cvw/api/v1/validation-processes/
(You can use the CMS as a domain too)

Expected response:

- If the user is not a staff, instructor, or validator of any validation process:
```
[]
```
- If the user is related to validation processes
```
[
    {
        "id": 14,
        "course": {
            "id": "course-v1:edX+2+2023"
        },
        "categories": [
            {
                "id": 1,
                "name": "español",
                "parent_category": null
            }
        ],
        "organization": {
            "id": 1,
            "name": "edX",
            "short_name": "edX"
        },
        "current_validation_user": null,
        "validation_body": {
            "id": 1,
            "validators": [
                {
                    "email": "[validator-1@example.com](mailto:validator-1@example.com)"
                },
                {
                    "email": "[validator-2@example.com](mailto:validator-2@example.com)"
                }
            ],
            "organizations": [
                {
                    "id": 1,
                    "name": "edX",
                    "short_name": "edX"
                }
            ],
            "name": "Validation Body Español"
        },
        "events": [
            {
                "id": 17,
                "create_at": "2023-09-06T01:27:21.383533Z",
                "status": "subm",
                "comment": "Esto es solo un comentario",
                "validation_process": 14,
                "user": 4,
                "reason": null
            },
            {
                "id": 18,
                "create_at": "2023-09-06T01:27:21.393923Z",
                "status": "exmp",
                "comment": "this course was automatic published due to exempt rules.",
                "validation_process": 14,
                "user": null,
                "reason": null
            }
        ]
    },
    {
        "id": 15,
        "course": {
            "id": "course-v1:edX+CS01+2023"
        },
        "categories": [
            {
                "id": 3,
                "name": "ingles",
                "parent_category": null
            }
        ],
        "organization": {
            "id": 1,
            "name": "edX",
            "short_name": "edX"
        },
        "current_validation_user": null,
        "validation_body": {
            "id": 2,
            "validators": [
                {
                    "email": "[admin@example.com](mailto:admin@example.com)"
                },
                {
                    "email": "[validator-1@example.com](mailto:validator-1@example.com)"
                },
                {
                    "email": "[validator-2@example.com](mailto:validator-2@example.com)"
                }
            ],
            "organizations": [
                {
                    "id": 1,
                    "name": "edX",
                    "short_name": "edX"
                }
            ],
            "name": "Validation Body Ingles"
        },
        "events": []
    }
]
```

## Some extra doc
- It could return 404 (if you send a username that does not exist or if you are trying to know the validation process of another person and you are not global staff)
