### PR TITLE
fix: typo, jwt support and return more info in the requests

### DIFF
--- a/platform_global_teacher_campus/api/v1/serializers.py
+++ b/platform_global_teacher_campus/api/v1/serializers.py
@@ -43,14 +43,14 @@ class OrganizationSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'short_name']
 
 
-class UserEmailSerializer(serializers.ModelSerializer):
+class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
-        fields = ['email']
+        fields = ['id', 'email', 'username']
 
 
 class ValidationBodySerializer(serializers.ModelSerializer):
-    validators = UserEmailSerializer(many=True, read_only=True)
+    validators = UserSerializer(many=True, read_only=True)
     organizations = OrganizationSerializer(many=True, read_only=True)
 
     validator_emails = serializers.ListField(child=serializers.CharField(), write_only=True)
@@ -86,7 +86,7 @@ class ValidationBodySerializer(serializers.ModelSerializer):
 class CourseSerializer(serializers.ModelSerializer):
     class Meta:
         model = CourseOverview
-        fields = ["id"]
+        fields = ["id", "display_name"]
 
 
 class ValidationRejectionReasonSerializer(serializers.ModelSerializer):
@@ -96,6 +96,7 @@ class ValidationRejectionReasonSerializer(serializers.ModelSerializer):
 
 
 class ValidationProcessEventSerializer(serializers.ModelSerializer):
+    user = UserSerializer(read_only=True)
 
     class Meta:
         model = ValidationProcessEvent

--- a/platform_global_teacher_campus/api/v1/views.py
+++ b/platform_global_teacher_campus/api/v1/views.py
@@ -130,6 +130,7 @@ def info_validation_process(request, course_id):
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
+@authentication_classes([JwtAuthentication])
 def get_validation_processes(request):
     """
     Returns the validation processes visible for the username provided or the request user.

--- a/platform_global_teacher_campus/models.py
+++ b/platform_global_teacher_campus/models.py
@@ -105,7 +105,7 @@ class ValidationProcessEvent(models.Model):
         null=True,
         related_name="events"
     )
-    create_at = models.DateTimeField(auto_now_add=True)
+    created_at = models.DateTimeField(auto_now_add=True)
     status = models.CharField(max_length=5, choices=StatusChoices.choices, default="subm")
     comment = models.TextField()
     user = models.ForeignKey(User, on_delete=models.SET_NULL, null=True)


### PR DESCRIPTION
## Description
This PR does some things:

- Change the UserEmailSerializer to UserSerializer (to have more info about the user).
- Use the UserSerializer in the Events.
- Add more info in the CourseSerializer.
- Correct the typo "create" to "created."
- Last minute fix: Add JWT auth in the get_validation_processes because I can make requests from my browser, but I couldn't with Postman and JWT as the rest of the endpoints.

Implications
- Change to UserSerializer: change the User serializer used in ValidationBodySerializer, and that only modify the response in the GET view to have more info. 
    - About the POST methods: 
        - submit_validation_process works well.
        - update_validation_process_state works well.
- Use the UserSerializer in the Events only affects the GET view, and add extra info.
- Add more info in the CourseSerializer only affects the GET view, and add extra info.
- About the typo, you can know the created_at attribute. It doesn't modify the ValidationProcessEventSerializer because it uses a model serializer with `"__all__"`.
- About the JWT, it works as the rest of the endpoints (We can't access from the browser but with the token).

## How to test
⚠️ You need to makemigrations and migrate because I edit a model to change from create to created.

(All the tests with JWT auth)

- Create a validation process
http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/course-v1:edX+CS01+2023/submit/
Body:
```
{
	"course_id": "course-v1:edX+CS01+2023",
	"category_ids": [
		1
	],
	"validation_body_id": 2,
	"comment": "Esto es solo un comentario"
}
```
(No exempt validation body), and change the course_id for your platform.
Expected result: It still works.
- Change the status of a validation process
http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/course-v1:edX+CS01+2023/update-state/
Body:
```
{
"status":"cncl",
"comment":":D"
}
```
Expected result: It still works.
- Get validation process
http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/course-v1:edX+CS01+2023
or
http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/

Expected result:
More info on the course and users
```
"course": {
            "id": "course-v1:edX+2+2023",
            "display_name": "Curso por publicar"
        },
...
"validators": [
                {
                    "id": 5,
                    "email": "validator-1@example.com",
                    "username": "validator-1"
                },
                {
                    "id": 6,
                    "email": "validator-2@example.com",
                    "username": "validator-2"
                }
            ],
```



