### PR TITLE
fix: change the on_delete null to cascade for validation process events

### DIFF
--- a/platform_global_teacher_campus/models.py
+++ b/platform_global_teacher_campus/models.py
@@ -101,8 +101,7 @@ class ValidationProcessEvent(models.Model):
 
     validation_process = models.ForeignKey(
         ValidationProcess,
-        on_delete=models.SET_NULL,
-        null=True,
+        on_delete=models.CASCADE,
         related_name="events"
     )
     create_at = models.DateTimeField(auto_now_add=True)


### PR DESCRIPTION
## Description
This PR changes the on_delete attribute; this deletes the events if the validation process associated is deleted.

⚠️ We need to migrate (makemigr and migr) for this change. The migration of this could be a little tricky because if you already have some events with validation in null, Django will solicit your opinion of what to do with those events (I selected Provide a one-off default now. And then I set a default a validation process id that I know its existence, and then manually in the admin I deleted that events)

## Context
It is possible to delete the Validation Process, and when we delete it, we set in the ValidationProcessEvent that field in null, but in the str method, we tried to get the id from a null item.

![Screenshot from 2023-09-15 00-00-13](https://github.com/eduNEXT/platform-global-teacher-campus/assets/35668326/b5beaf61-4949-4c11-8cda-cc849ed31be8)
Screenshot of error trying to enter in http://local.overhang.io:8000/admin/platform_global_teacher_campus/validationprocessevent/

📌 **Note:** For me, it makes sense that we delete the events if the validation process is deleted, but if, for some reason, we want to have all the events, we could change the str method, and that's it.

## How to test
- Enter http://local.overhang.io:8000/admin/platform_global_teacher_campus/validationprocessevent/ without problem
- Eliminate a validation process and eliminate its events.



