### PR TITLE
fix: allow to validation process pass from review to submit

### DIFF
--- a/platform_global_teacher_campus/models.py
+++ b/platform_global_teacher_campus/models.py
@@ -160,6 +160,7 @@ class ValidationProcessEvent(models.Model):
                 cls.StatusChoices.DRAFT,
                 cls.StatusChoices.APPROVED,
                 cls.StatusChoices.DISAPPROVED,
+                cls.StatusChoices.SUBMITTED,
             ],
             cls.StatusChoices.DRAFT: [
                 cls.StatusChoices.SUBMITTED,


### PR DESCRIPTION
## Description
This PR supports the case that a validator no longer reviews a validation process and then wants to open it again to allow another validator to take it.

## How to test it
- As staff of the course, create a Validation Process
- Assign a current validator user and, with him, create a JWT and make calls to:
    - Update state to in review (e.g., http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/course-v1:edX+test+2023/update-state/ body: {"status":"revi","comment":"In review"])
    - Update state to submit (e.g., http://studio.local.overhang.io:8001/plugin-cvw/api/v1/validation-processes/course-v1:edX+test+2023/update-state/ body: {"status":"subm","comment":"Submit again because the reviewers it's no longer available"])

Expected result: be able to pass from review to submitted.
