### PR TITLE
feat: added new endpoint for validation bodies by course

### DIFF
--- a/platform_global_teacher_campus/api/v1/urls.py
+++ b/platform_global_teacher_campus/api/v1/urls.py
@@ -12,7 +12,7 @@ router.register(r'categories', views.CourseCategoryViewSet)
 router.register(r'validation-bodies', views.ValidationBodyViewSet)
 
 urlpatterns = [
-    path('', include((router.urls, app_name), namespace="pgtc-api")),
+
     path(
         'validation-processes/<str:course_id>/submit/',
         views.submit_validation_process,
@@ -25,4 +25,7 @@ urlpatterns = [
     path('validation-processes/', views.get_validation_processes, name="get-validation-processes"),
     path('user-info/', views.user_info, name="get_user_info"),
     path('rejection-reasons/', views.get_rejection_reasons, name="get-rejection-reasons"),
+    path('validation-bodies/<str:course_id>/', views.get_validation_bodies_by_course, name="get-validation-bodies-by-course"),
+    path('', include((router.urls, app_name), namespace="pgtc-api")),
+
 ]

--- a/platform_global_teacher_campus/api/v1/urls.py
+++ b/platform_global_teacher_campus/api/v1/urls.py
@@ -25,7 +25,9 @@ urlpatterns = [
     path('validation-processes/', views.get_validation_processes, name="get-validation-processes"),
     path('user-info/', views.user_info, name="get_user_info"),
     path('rejection-reasons/', views.get_rejection_reasons, name="get-rejection-reasons"),
-    path('validation-bodies/<str:course_id>/', views.get_validation_bodies_by_course, name="get-validation-bodies-by-course"),
+    path('validation-bodies/<str:course_id>/',
+         views.get_validation_bodies_by_course,
+         name="get-validation-bodies-by-course"),
     path('', include((router.urls, app_name), namespace="pgtc-api")),
 
 ]

--- a/platform_global_teacher_campus/api/v1/views.py
+++ b/platform_global_teacher_campus/api/v1/views.py
@@ -23,11 +23,11 @@ from platform_global_teacher_campus.edxapp_wrapper.course_roles import (
 from platform_global_teacher_campus.edxapp_wrapper.courses import get_course_overview
 from platform_global_teacher_campus.models import (
     CourseCategory,
+    Organization,
     ValidationBody,
     ValidationProcess,
     ValidationProcessEvent,
     ValidationRejectionReason,
-    Organization,
 )
 
 from .publish_utils import publish_course

--- a/platform_global_teacher_campus/api/v1/views.py
+++ b/platform_global_teacher_campus/api/v1/views.py
@@ -27,6 +27,7 @@ from platform_global_teacher_campus.models import (
     ValidationProcess,
     ValidationProcessEvent,
     ValidationRejectionReason,
+    Organization,
 )
 
 from .publish_utils import publish_course
@@ -244,4 +245,21 @@ def get_rejection_reasons(request):
         return Response(data={}, status=status.HTTP_200_OK)
 
     serializer = ValidationRejectionReasonSerializer(rejection_reasons, many=True)
+    return Response(data=serializer.data, status=status.HTTP_200_OK)
+
+
+@api_view(['GET'])
+@permission_classes([IsAuthenticated])
+@authentication_classes([JwtAuthentication])
+def get_validation_bodies_by_course(request, course_id):
+    try:
+        course = CourseOverview.objects.get(id=course_id)
+    except CourseOverview.DoesNotExist:
+        return Response(status=status.HTTP_404_NOT_FOUND)
+
+    organization_of_course = course.org
+    organization_id = Organization.objects.get(name=organization_of_course).id
+    validation_bodies_by_org = ValidationBody.objects.filter(organizations=organization_id)
+    serializer = ValidationBodySerializer(validation_bodies_by_org, many=True)
+
     return Response(data=serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
This PR adds a new endpoint: {{domain}}/api/v1/validation-bodies/course_id and changes the urlpatterns to keep the old endpoint without the course_id.

**How to test**

1. Make sure you have different couses with different organizations created
2. Go to {{domain}}/api/v1/validation-bodies/course_id replace course id with the actual course you want to test
3. Don't forget to add the JWT Token as an autorization header if you're using Postman
4. You should see a response if you provided the url with a valid course_id:
```json
[
    {
        "id": 4,
        "validators": [
            {
                "id": 9,
                "email": "val1@example.com",
                "username": "val1",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 3,
                "name": "demo",
                "short_name": "demo"
            }
        ],
        "name": "validationbodydemo1"
    },
    {
        "id": 5,
        "validators": [
            {
                "id": 6,
                "email": "validador1@example.com",
                "username": "validador1",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 3,
                "name": "demo",
                "short_name": "demo"
            }
        ],
        "name": "validationbodydemo2"
    }
]
```
5. Don't forget to test the old endpoint {{domain}}/api/v1/validation-bodies to get all the validation bodies avaible:

```json
[
    {
        "id": 1,
        "validators": [
            {
                "id": 4,
                "email": "admin@example.com",
                "username": "admin",
                "full_name": "Andres Espinel"
            }
        ],
        "organizations": [
            {
                "id": 1,
                "name": "edX",
                "short_name": "edX"
            }
        ],
        "name": "validationBody1"
    },
    {
        "id": 2,
        "validators": [
            {
                "id": 5,
                "email": "profe@example.com",
                "username": "profe",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 1,
                "name": "edX",
                "short_name": "edX"
            }
        ],
        "name": "validationbodyedX1"
    },
    {
        "id": 3,
        "validators": [
            {
                "id": 6,
                "email": "validador1@example.com",
                "username": "validador1",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 1,
                "name": "edX",
                "short_name": "edX"
            }
        ],
        "name": "validationbodyedX2"
    },
    {
        "id": 4,
        "validators": [
            {
                "id": 9,
                "email": "val1@example.com",
                "username": "val1",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 3,
                "name": "demo",
                "short_name": "demo"
            }
        ],
        "name": "validationbodydemo1"
    },
    {
        "id": 5,
        "validators": [
            {
                "id": 6,
                "email": "validador1@example.com",
                "username": "validador1",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 3,
                "name": "demo",
                "short_name": "demo"
            }
        ],
        "name": "validationbodydemo2"
    },
    {
        "id": 6,
        "validators": [
            {
                "id": 10,
                "email": "val2@example.com",
                "username": "val2",
                "full_name": null
            }
        ],
        "organizations": [
            {
                "id": 2,
                "name": "test",
                "short_name": "test"
            }
        ],
        "name": "validationbodytest1"
    }
]
```

